### PR TITLE
Bugfix - Situação não considerada no código do transbordo

### DIFF
--- a/src/Frete.php
+++ b/src/Frete.php
@@ -288,7 +288,7 @@ class Frete
 
         if (($medida > 66) or ($pesoTotal > 30)) {
             if ($pesoTotal > 30 && $medida < 67) {
-                $somaFrete = $this->trasnbordoDePeso($retornaUrl, $pesoTotal, $medida);
+                $somaFrete = $this->transbordoDePeso($retornaUrl, $pesoTotal, $medida);
             } elseif ($pesoTotal > 30  &&  $medida > 66) {
                 $somaFrete = $this->transbordoDePesoEMedida($retornaUrl, $pesoTotal, $medida);
             }
@@ -384,7 +384,7 @@ class Frete
     }
 
     // TODO: Formatar esta função
-    private function trasnbordoDePeso($retornaUrl, $Peso, $Medida)
+    private function transbordoDePeso($retornaUrl, $Peso, $Medida)
     {
         $consultas = array();
 


### PR DESCRIPTION
Olá,

conforme conversamos na issue #3 , criei um novo método (`transbordoDeMedida()`) para tratar essa questão. 

Nesse novo método, passei o array de produtos para calcular novamente a cubagem, só que dessa vez o cálculo é por cada produto, começando pela quantidade, onde vou verificando se a `$medida` é menor que **66** e inserindo em novas `$caixas`.

Fico no aguardo do feedback e espero ter ajudado galera, valeu!
